### PR TITLE
Add initial Sendgrid service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    working_directory: ~/omg
+
+    steps:
+      - checkout
+      - run:
+          name: Install node@10.14.1
+          command: |
+            set +e
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install v10.14.1 && nvm alias default v10.14.1
+            # Each step uses the same `$BASH_ENV`, so need to modify it
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+      - run: npm i omg
+      - run: ./hooks/pre_build
+      - run: npx omg build

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,15 @@
-# Compiled class file
-*.class
+# Created by https://www.gitignore.io/api/scala
+# Edit at https://www.gitignore.io/?templates=scala
 
-# Log file
+### Scala ###
+*.class
 *.log
 
-# BlueJ files
-*.ctxt
+# End of https://www.gitignore.io/api/scala
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+/project/plugins/project
+project/boot
+target/
+.idea
+omg-sendgrid.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM        java:8-jre-alpine
+
+RUN         apk update && apk add bash
+RUN         mkdir /app
+ADD         target/universal/stage /app/
+
+ENTRYPOINT ["/app/bin/omg-sendgrid"]

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ Usage
 # Storyscript
 sendgrid send_one from: "sender@dummy.com" to: "recipient@dummy.com" subject: "Hello" content: "…"
 sendgrid send_many
-  personalizations: [
-    to: [{email: "recipient1@dummy.com", name: "Mister Dummy"}],
-    subject: "Dear Mr. Dummy",
-    dynamic_template_data: {
-      dynamic_parameter: "set with a value",
+  personalizations: [{
+    "to": [{"email": "recipient1@dummy.com", "name": "Mister Dummy"}],
+    "subject": "Dear Mr. Dummy",
+    "dynamic_template_data": {
+      dynamic_parameter: "set with a value"
     }
-  ],
-  from: {email: "sender@dummy.com", name: "My sender name"}
+  }]
+  from: {"email": "sender@dummy.com", "name": "My sender name"}
   content: [{
-    type: "text/plain",
-    value: "Hello World!"
+    "type": "text/plain",
+    "value": "Hello World!"
   }]
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # sendgrid
 An OMG service to access the Sendgrid email API
+
+Usage
+-----
+
+```coffee
+# Storyscript
+sendgrid simple from: "sender@dummy.com" to: "recipient@dummy.com" subject: "Hello" content: "…"
+sendgrid advanced
+  personalizations: [
+    to: [{email: "recipient1@dummy.com", name: "Mister Dummy"}],
+    subject: "Dear Mr. Dummy",
+    dynamic_template_data: {
+      dynamic_parameter: "set with a value",
+    }
+  ],
+  from: {email: "sender@dummy.com", name: "My sender name"}
+  content: [{
+    type: "text/plain",
+    value: "Hello World!"
+  }]
+```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Usage
 
 ```coffee
 # Storyscript
-sendgrid simple from: "sender@dummy.com" to: "recipient@dummy.com" subject: "Hello" content: "…"
-sendgrid advanced
+sendgrid send_one from: "sender@dummy.com" to: "recipient@dummy.com" subject: "Hello" content: "…"
+sendgrid send_many
   personalizations: [
     to: [{email: "recipient1@dummy.com", name: "Mister Dummy"}],
     subject: "Dear Mr. Dummy",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ sendgrid send_many
     "to": [{"email": "recipient1@dummy.com", "name": "Mister Dummy"}],
     "subject": "Dear Mr. Dummy",
     "dynamic_template_data": {
-      dynamic_parameter: "set with a value"
+      "dynamic_parameter": "set with a value"
     }
   }]
   from: {"email": "sender@dummy.com", "name": "My sender name"}

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,20 @@
+enablePlugins(JavaAppPackaging)
+
+name := "omg-sendgrid"
+organization := "asyncy"
+version := "0.1"
+scalaVersion := "2.11.8"
+scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
+mainClass in Compile := Some("SendGridApp")
+
+libraryDependencies ++= {
+  val akkaHttpVersion = "10.0.10"
+
+  Seq(
+    "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-jackson" % akkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
+    "com.sendgrid" % "sendgrid-java" % "4.3.0",
+  )
+}
+

--- a/hooks/pre-build
+++ b/hooks/pre-build
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker run -it --rm -v "$(pwd)":/src hseeberger/scala-sbt /bin/bash -c \
-    "(cd /src && sbt universal:stage)"

--- a/hooks/pre-build
+++ b/hooks/pre-build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker run -it --rm -v "$(pwd)":/src hseeberger/scala-sbt /bin/bash -c \
+    "(cd /src && sbt universal:stage)"

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run -it --rm -v "$(pwd)":/src hseeberger/scala-sbt:8u181_2.12.6_1.2.1 \
+    /bin/bash -c \
+    "(cd /src && sbt universal:stage)"

--- a/microservice.yml
+++ b/microservice.yml
@@ -109,3 +109,4 @@ environment:
     help: |
       Create a Sendgrid account and register an API key at https://app.sendgrid.com/settings/api_keys
     type: string
+    required: true

--- a/microservice.yml
+++ b/microservice.yml
@@ -3,9 +3,9 @@ lifecycle:
   startup:
     command: ["/app/bin/omg-sendgrid"]
 actions:
-  simple:
+  send_one:
     http:
-      path: /simple
+      path: /send_one
       method: post
       port: 8000
     arguments:
@@ -36,9 +36,9 @@ actions:
         message_id:
           type: string
 
-  advanced:
+  send_many:
     http:
-      path: /advanced
+      path: /send_many
       method: post
       port: 8000
     arguments:

--- a/microservice.yml
+++ b/microservice.yml
@@ -1,0 +1,111 @@
+omg: 1
+lifecycle:
+  startup:
+    command: ["/app/bin/omg-sendgrid"]
+actions:
+  simple:
+    http:
+      path: /simple
+      method: post
+      port: 8000
+    arguments:
+      from:
+        type: string
+        required: true
+        in: requestBody
+      to:
+        type: string
+        required: true
+        in: requestBody
+      subject:
+        type: string
+        required: true
+        in: requestBody
+      content:
+        type: string
+        required: true
+        in: requestBody
+      content_type:
+        type: string
+        required: true
+        in: requestBody
+    output:
+      type: object
+      contentType: application/json
+      properties:
+        message_id:
+          type: string
+
+  advanced:
+    http:
+      path: /advanced
+      method: post
+      port: 8000
+    arguments:
+      personalizations:
+        type: object
+        required: true
+        in: requestBody
+      from:
+        type: object
+        required: true
+        in: requestBody
+      subject:
+        type: string
+        in: requestBody
+      content:
+        type: list
+        required: true
+        in: requestBody
+      reply_to:
+        type: object
+        in: requestBody
+      attachments:
+        type: list
+        in: requestBody
+      template_id:
+        type: string
+        in: requestBody
+      sections:
+        type: object
+        in: requestBody
+      headers:
+        type: object
+        in: requestBody
+      categories:
+        type: list
+        in: requestBody
+      custom_args:
+        type: object
+        in: requestBody
+      send_at:
+        type: int
+        in: requestBody
+      batch_id:
+        type: string
+        in: requestBody
+      asm:
+        type: object
+        in: requestBody
+      ip_pool_name:
+        type: string
+        in: requestBody
+      mail_settings:
+        type: object
+        in: requestBody
+      tracking_settings:
+        type: object
+        in: requestBody
+
+    output:
+      type: object
+      contentType: application/json
+      properties:
+        message_id:
+          type: string
+
+environment:
+  SENDGRID_API_TOKEN:
+    help: |
+      Create a Sendgrid account and register an API key at https://app.sendgrid.com/settings/api_keys
+    type: string

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.15")

--- a/src/main/scala/SendGridApp.scala
+++ b/src/main/scala/SendGridApp.scala
@@ -284,10 +284,6 @@ object SendGridApp {
     val sendgridService = new SendGridService(apiToken)
     val bindingFuture = Http().bindAndHandle(sendgridService.route, "localhost", 8080)
 
-    println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
-    StdIn.readLine() // let it run until user presses return
-    bindingFuture
-      .flatMap(_.unbind()) // trigger unbinding from the port
-      .onComplete(_ => system.terminate()) // and shutdown when done
+    println(s"Server online at http://localhost:8080/")
   }
 }

--- a/src/main/scala/SendGridApp.scala
+++ b/src/main/scala/SendGridApp.scala
@@ -238,7 +238,7 @@ class SendGridService(apiToken: String) extends Directives with JsonSupport {
     handleRejections(rejectionHandler) {
       handleExceptions(exceptionHandler) {
         extractRequestContext { ctx =>
-          path("simple") {
+          path("send_one") {
             post {
               entity(as[EmailRequest]) { email =>
                 val content = new Content(email.content_type getOrElse "text/plain", email.content)
@@ -251,7 +251,7 @@ class SendGridService(apiToken: String) extends Directives with JsonSupport {
               }
             }
           } ~
-          path("advanced") {
+          path("send_many") {
             post {
               entity(as[SendGridRequest]) { email =>
                   val request = new Request();

--- a/src/main/scala/SendGridApp.scala
+++ b/src/main/scala/SendGridApp.scala
@@ -1,0 +1,293 @@
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server._
+import akka.stream.ActorMaterializer
+import StatusCodes._
+import scala.io.StdIn
+import scala.collection.JavaConverters._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json._
+import com.sendgrid._
+import java.io.IOException
+
+// SendGrid API objects
+
+case class SendGridEmail(
+  email: String,
+  name: Option[String]
+)
+
+case class SendGridPersonalization(
+  to: List[SendGridEmail],
+  cc: Option[List[SendGridEmail]],
+  bcc: Option[List[SendGridEmail]],
+  subject: Option[String],
+  headers: Option[Map[String,String]],
+  substitutions: Option[Map[String,String]],
+  dynamic_template_data: Option[Map[String,String]],
+  custom_args: Option[Map[String,String]],
+  send_at: Option[Int]
+)
+
+case class SendGridContents(
+  _type: String,
+  value: String
+)
+
+case class SendGridAttachment(
+  content: String,
+  _type: Option[String],
+  filename: String,
+  disposition: Option[String],
+  content_id: Option[String]
+)
+
+case class SendGridAsm(
+  group_id: Int,
+  groups_to_display: Option[List[Int]]
+)
+
+case class SendGridMailSettingsBCC(
+  enable: Option[Boolean],
+  email: Option[String]
+)
+
+case class SendGridMailSettingsBypass(
+  enable: Option[Boolean]
+)
+
+case class SendGridMailSettingsFooter(
+  enable: Option[Boolean],
+  text: Option[String],
+  html: Option[String]
+)
+
+case class SendGridMailSettingsSandbox(
+  enable: Option[Boolean]
+)
+
+case class SendGridMailSettingsSpamCheck(
+  enable: Option[Boolean],
+  threshold: Option[Int],
+  post_to_url: Option[String]
+)
+
+case class SendGridMailSettings(
+  bcc: Option[SendGridMailSettingsBCC],
+  bypass_list_management: Option[SendGridMailSettingsBypass],
+  footer: Option[SendGridMailSettingsFooter],
+  sandbox_mode: Option[SendGridMailSettingsSandbox],
+  spam_check: Option[SendGridMailSettingsSpamCheck]
+)
+
+case class SendGridClickTracking(
+  enable: Option[Boolean],
+  enable_text: Option[Boolean]
+)
+
+case class SendGridOpenTracking(
+  enable: Option[Boolean],
+  substitution_tag: Option[String]
+)
+
+case class SendGridSubscriptionTracking(
+  enable: Option[Boolean],
+  text: Option[String],
+  html: Option[String],
+  substitution_tag: Option[String]
+)
+
+case class SendGridGAnalyticsTracking(
+  enable: Option[Boolean],
+  utm_source: Option[String],
+  utm_medium: Option[String],
+  utm_term: Option[String],
+  utm_content: Option[String],
+  utm_campaign: Option[String]
+)
+
+case class SendGridTrackingSettings(
+  click_traing: Option[SendGridClickTracking],
+  open_tracking: Option[SendGridOpenTracking],
+  subscription_tracking: Option[SendGridSubscriptionTracking],
+  ganalytics_tracking: Option[SendGridGAnalyticsTracking]
+)
+
+case class SendGridRequest(
+  personalizations: List[SendGridPersonalization],
+  from: SendGridEmail,
+  reply_to: Option[SendGridEmail],
+  subject: Option[String],
+  content: List[SendGridContents],
+  attachments: Option[List[SendGridAttachment]],
+  template_id: Option[String],
+  sections: Option[Map[String,String]],
+  headers: Option[Map[String,String]],
+  categories: Option[List[String]],
+  custom_args: Option[Map[String,String]],
+  send_at: Option[Int],
+  batch_id: Option[String],
+  asm: Option[SendGridAsm],
+  ip_pool_name: Option[String],
+  mail_settings: Option[SendGridMailSettings],
+  tracking_settings: Option[SendGridTrackingSettings]
+)
+
+case class SendGridError(
+  message: String,
+  field: Option[String],
+  help: Option[String]
+)
+
+case class SendGridErrorResponse(
+  errors: Option[List[SendGridError]]
+)
+
+// -- own request objects
+
+case class EmailRequest(
+  from: String,
+  to: String,
+  subject: String,
+  content: String,
+  content_type: Option[String] = Some("text/plain")
+)
+
+case class ErrorMessage(success: Boolean, message: String)
+case class UserResponse(message_id: String)
+
+// Teach SprayJson about all our objects
+// https://github.com/spray/spray-json
+trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val emailFormat = jsonFormat5(EmailRequest)
+  implicit val errorFormat = jsonFormat2(ErrorMessage)
+  implicit val userResponse = jsonFormat1(UserResponse)
+
+  implicit val sendGridEmail = jsonFormat2(SendGridEmail)
+  implicit val sendGridPersonalization = jsonFormat9(SendGridPersonalization)
+  implicit val sendGridContents = jsonFormat(SendGridContents.apply, "type", "value")
+  implicit val sendGridAttachment = jsonFormat(SendGridAttachment.apply, "content", "type", "filename", "disposition", "content_id")
+  implicit val sendGridAsm = jsonFormat2(SendGridAsm)
+  implicit val sendGridMailSettingsBCC = jsonFormat2(SendGridMailSettingsBCC)
+  implicit val sendGridMailSettingsBypass = jsonFormat1(SendGridMailSettingsBypass)
+  implicit val sendGridMailSettingsFooter = jsonFormat3(SendGridMailSettingsFooter)
+  implicit val sendGridMailSettingsSandbox = jsonFormat1(SendGridMailSettingsSandbox)
+  implicit val sendGridMailSettingsSpamCheck = jsonFormat3(SendGridMailSettingsSpamCheck)
+  implicit val sendGridMailSettings = jsonFormat5(SendGridMailSettings)
+  implicit val sendGridClickTracking = jsonFormat2(SendGridClickTracking)
+  implicit val sendGridOpenTracking = jsonFormat2(SendGridOpenTracking)
+  implicit val sendGridSubscriptionTracking = jsonFormat4(SendGridSubscriptionTracking)
+  implicit val sendGridGAnalyticsTracking = jsonFormat6(SendGridGAnalyticsTracking)
+  implicit val sendGridTrackingSettings = jsonFormat4(SendGridTrackingSettings)
+  implicit val sendGridRequest = jsonFormat17(SendGridRequest)
+
+  implicit val sendGridError = jsonFormat3(SendGridError)
+  implicit val sendGridErrorResponse = jsonFormat1(SendGridErrorResponse)
+}
+
+// https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html
+class SendGridService(apiToken: String) extends Directives with JsonSupport {
+
+  implicit val system = ActorSystem("omg-sendgrid-client")
+  implicit val materializer = ActorMaterializer()
+  implicit val executionContext = system.dispatcher
+  val sg = new SendGrid(apiToken)
+
+  val exceptionHandler = ExceptionHandler {
+    case e: IOException =>
+        val msg = e.getMessage
+        // check whether the error comes from sendgrid and is due to bad user input
+        val ioErrorStart = "Request returned status Code 400Body:"
+        if (msg.startsWith(ioErrorStart)) {
+          val j = msg.substring(ioErrorStart.length()).parseJson.convertTo[SendGridErrorResponse]
+          val errorMsg = j.errors.getOrElse(List()).map(e => e.message).mkString(",")
+          complete((BadRequest, ErrorMessage(false, errorMsg)))
+        } else {
+          complete((InternalServerError, ErrorMessage(false, s"Internal error: ${e.getMessage}")))
+        }
+    case e: Exception =>
+      extractUri { uri =>
+        println(s"Request to $uri failed: " + e.toString)
+        complete((InternalServerError, ErrorMessage(false, s"Internal error: ${e.getMessage}")))
+      }
+  }
+
+  val rejectionHandler = RejectionHandler.newBuilder()
+    .handle { case MalformedRequestContentRejection(msg, _) =>
+      complete((BadRequest, ErrorMessage(false, msg)))
+    }
+    .handleAll[MethodRejection] { methodRejections =>
+      val names = methodRejections.map(_.supported.name)
+      complete((MethodNotAllowed, ErrorMessage(false, s"Invalid method! Supported: ${names mkString " or "}!")))
+    }
+    .handleNotFound { complete((NotFound, ErrorMessage(false, "Invalid route."))) }
+    .result()
+
+  // return the message id or the error message
+  def handleSGResponse(response: Response, requestContext: RequestContext) : StandardRoute = {
+    if (response.getStatusCode() / 100 == 2) {
+      val headers = response.getHeaders().asScala
+      complete(UserResponse(headers.getOrElse("X-Message-Id", "ERROR")))
+    } else {
+      complete(ErrorMessage(true, response.getBody()))
+    }
+  }
+
+  val route =
+    handleRejections(rejectionHandler) {
+      handleExceptions(exceptionHandler) {
+        extractRequestContext { ctx =>
+          path("simple") {
+            post {
+              entity(as[EmailRequest]) { email =>
+                val content = new Content(email.content_type getOrElse "text/plain", email.content)
+                val mail = new Mail(new Email(email.from), email.subject, new Email(email.to), content)
+                val request = new Request()
+                request.setMethod(Method.POST)
+                request.setEndpoint("mail/send")
+                request.setBody(mail.build())
+                handleSGResponse(sg.api(request), ctx)
+              }
+            }
+          } ~
+          path("advanced") {
+            post {
+              entity(as[SendGridRequest]) { email =>
+                  val request = new Request();
+                  request.setMethod(Method.POST);
+                  request.setEndpoint("mail/send");
+                  request.setBody(email.toJson.compactPrint)
+                  handleSGResponse(sg.api(request), ctx)
+              }
+            }
+          }
+        }
+      }
+    }
+}
+
+object SendGridApp {
+  def main(args: Array[String]) {
+
+    implicit val system = ActorSystem("omg-sendgrid")
+    implicit val materializer = ActorMaterializer()
+    implicit val executionContext = system.dispatcher
+
+    if (!sys.env.contains("SENDGRID_API_TOKEN")) {
+      println("No SENDGRID_API_TOKEN provided.")
+      system.terminate()
+      System.exit(1)
+    }
+
+    val apiToken =  sys.env("SENDGRID_API_TOKEN")
+    val sendgridService = new SendGridService(apiToken)
+    val bindingFuture = Http().bindAndHandle(sendgridService.route, "localhost", 8080)
+
+    println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
+    StdIn.readLine() // let it run until user presses return
+    bindingFuture
+      .flatMap(_.unbind()) // trigger unbinding from the port
+      .onComplete(_ => system.terminate()) // and shutdown when done
+  }
+}


### PR DESCRIPTION
- written in Scala
- I wasn't sure on how to wrap the API in the best idiomatic Storyscript way

For now I went with the following approach:

```
/simple (simplified endpoint for just sending one email to one person)
/advanced (full Sendgrid API)
```

I wrapped the entire Sendgrid API response object, s.t. a user gets a nice error message (though I'm not fully sure anymore whether this was worth it as at the moment the service doesn't modify the object, but just forwards it to Sendgrid).

Other notes:
- `dynamic_template_data` isn't documented at https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html, but still works :man_shrugging:
- the docker image gets built with the DockerHub `pre-hook` which compiles everything, s.t. during the actual Docker image build, it just needs to copy over the archive and can use a slim `alpine-jre` environment

For local builds, that's simply e.g. `./hooks/pre-build && docker build -t sendgrid .`. Though of course, running `sbt` directly is a lot faster as then the build cache can be used, e.g.

```
sbt compile run
```

Or to create a new archive for the Docker image it's just:

```
sbt universal:stage
```

Other questions:
- we should probably add more convenience overloads for `simple` like e.g. accepting a list of email addresses or instead of just the email address also a `{email, name}` object (though currently the microservice specification doesn't support `typeOf` or similar, so this would need to be `any`)
- In theory we could query [all transactional templates](https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/templates.html) of a user, s.t. we can map the template name with the id, but I'm not sure whether that's worth it as this creates more troubles like dealing with the case when the name is not ambiguous